### PR TITLE
Add Playwright e2e testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: Build and unit tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
 
 jobs:
   build:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,28 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,10 +14,32 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+
       - name: Install dependencies
         run: npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+
+      - name: Get installed Playwright version
+        #  see https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
+
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
       - name: Run Playwright tests
         run: npx playwright test
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get installed Playwright version
         #  see https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
-
+        #  note location of version in package-lock is dependent on the lockfileVersion
+      - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ npm-debug.log*
 
 # production
 /dist
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "vite-tsconfig-paths": "^4.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.38.1",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
+        "@types/node": "^18.17.1",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "@vitejs/plugin-react": "^4.0.3",
@@ -1112,6 +1114,21 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
+      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.38.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.23",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
@@ -1265,9 +1282,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
-      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==",
+      "version": "18.17.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.19.tgz",
+      "integrity": "sha512-+pMhShR3Or5GR0/sp4Da7FnhVmTalWm81M6MkEldbwjETSaPalw138Z4KdpQaistvqQxLB7Cy4xwYdxpbSOs9Q==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -4740,6 +4757,50 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.38.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "preview": "vite preview",
     "lint": "eslint src --ext .js,.ts,.jsx,.tsx",
     "test": "vitest",
-    "test-ui": "npm run test -- --ui"
+    "test-ui": "npm run test -- --ui",
+    "e2e": "npx playwright test",
+    "e2e-ui": "npx playwright test --ui"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -20,9 +22,11 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.38.1",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@types/node": "^18.17.1",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
     "@vitejs/plugin-react": "^4.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:5173',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -6,7 +6,7 @@ describe('App', () => {
   test('renders App component', () => {
     const { container } = render(<App />);
 
-    expect(screen.getByText('App')).toBeInTheDocument();
+    expect(screen.getByTestId('app')).toBeInTheDocument();
 
     // Verify css module className
     expect(container.querySelector('.container')).toBeTruthy();

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,5 +1,9 @@
 import css from './App.module.css';
 
-const App = () => <div className={css.container}>App</div>;
+const App = () => (
+  <div data-testid="app" className={css.container}>
+    App
+  </div>
+);
 
 export default App;

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(
+    page.getByRole('heading', { name: 'Installation' }),
+  ).toBeVisible();
+});

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test('has title', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(/^Mondo$/);
+  });
+
+  test('has the App', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByTestId('app')).toBeInViewport();
+  });
+});

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,0 +1,11 @@
+# End to end tests
+
+These tests run the application as a user would in a headless browser using Playwright.
+
+See https://playwright.dev/docs/intro for documentation.
+
+- see the [configuration](../playwright.config.ts) file
+- `npm run e2e` will run the tests in the console
+- `npm run e2e-ui` will run the tests in an environment with a headed browser (useful for writing and debugging tests)
+- Tests will also run in CI on push and PR
+- Also consider installing the [vscode extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    exclude: ['**/node_modules/**', '**/dist/**', './tests', './test-*'],
     setupFiles: './vitest.setup.ts',
     css: {
       modules: {


### PR DESCRIPTION
Add the dependencies, config and an example test.

Uses Playwright browser caching as documented in https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/ However, it looks like `"lockfileVersion": 3` has a different structure so getting the playwright version required a change to:
```
node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)"
```